### PR TITLE
Update to OpenCrypto.js

### DIFF
--- a/lib/OpenCrypto.js
+++ b/lib/OpenCrypto.js
@@ -10,17 +10,17 @@
 
 /**
  * MIT License
- * 
+ *
  * Copyright (c) 2016 Peter Bielak
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
  * to whom the Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
  * Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -53,24 +53,24 @@ function initB64() {
  * Copyright (c) 2012 Niklas von Hertzen
  * MIT License
  */
-      
+
 function encodeAb(arrayBuffer) {
     var bytes = new Uint8Array(arrayBuffer),
     i, len = bytes.length, base64 = '';
-    
+
     for (i = 0; i < len; i+=3) {
         base64 += chars[bytes[i] >> 2];
         base64 += chars[((bytes[i] & 3) << 4) | (bytes[i + 1] >> 4)];
         base64 += chars[((bytes[i + 1] & 15) << 2) | (bytes[i + 2] >> 6)];
         base64 += chars[bytes[i + 2] & 63];
     }
-    
+
     if ((len % 3) === 2) {
         base64 = base64.substring(0, base64.length - 1) + '=';
     } else if (len % 3 === 1) {
         base64 = base64.substring(0, base64.length - 2) + '==';
     }
-    
+
     return base64;
 }
 
@@ -78,28 +78,28 @@ function decodeAb(base64) {
     var bufferLength = base64.length * 0.75,
     len = base64.length, i, p = 0,
     encoded1, encoded2, encoded3, encoded4;
-    
+
     if (base64[base64.length - 1] === '=') {
         bufferLength--;
         if (base64[base64.length - 2] === '=') {
             bufferLength--;
         }
     }
-    
+
     var arrayBuffer = new ArrayBuffer(bufferLength),
     bytes = new Uint8Array(arrayBuffer);
-    
+
     for (i = 0; i < len; i+=4) {
         encoded1 = lookup[base64.charCodeAt(i)];
         encoded2 = lookup[base64.charCodeAt(i+1)];
         encoded3 = lookup[base64.charCodeAt(i+2)];
         encoded4 = lookup[base64.charCodeAt(i+3)];
-        
+
         bytes[p++] = (encoded1 << 2) | (encoded2 >> 4);
         bytes[p++] = ((encoded2 & 15) << 4) | (encoded3 >> 2);
         bytes[p++] = ((encoded3 & 3) << 6) | (encoded4 & 63);
     }
-    
+
     return arrayBuffer;
 }
 
@@ -109,7 +109,7 @@ function addNewLines(str) {
         finalString += str.substring(0, 64) + '\r\n';
         str = str.substring(64);
     }
-    
+
     return finalString;
 }
 
@@ -117,67 +117,223 @@ function removeLines(str) {
     return str.replace(/\r?\n|\r/g, '');
 }
 
-function toAsn1(arrayBuffer, salt, iv, crypt) {
-    var key = crypt.arrayBufferToHexString(arrayBuffer);
-    
-    var KEY_OCTET = '04820' + (key.length / 2).toString(16) + key;
+function d2h(d) {
+    var h = null;
+    if (typeof d === 'number') {
+        h = (d).toString(16)
+    } else if (typeof d === 'string') {
+        h = (d.length / 2).toString(16)
+    }
+
+    return h.length % 2 ? '0' + h : h;
+}
+
+function toAsn1(wrappedKey, salt, iv, iterations, hash, cipher, keyLength, self) {
+    var opt = {};
+    wrappedKey = self.arrayBufferToHexString(wrappedKey);
+    salt = self.arrayBufferToHexString(salt);
+    iv = self.arrayBufferToHexString(iv);
+    iterations = d2h(iterations);
+
     var PBES2_OID = '06092a864886f70d01050d';
     var PBKDF2_OID = '06092a864886f70d01050c';
-    var AESCBC_OID = '060960864801650304012a';
-    var SALT_OCTET = '0410' + crypt.arrayBufferToHexString(salt);
-    var ITER_INTEGER = '02020800';
-    var IV_OCTET = '0410' + crypt.arrayBufferToHexString(iv);
-    var SEQUENCE_LENGTH = (87 + (key.length / 2)).toString(16);
-    var SEQUENCE = '30820' + SEQUENCE_LENGTH + '3051' + PBES2_OID + '30443023' + PBKDF2_OID + '3016' + SALT_OCTET + ITER_INTEGER + '301d' + AESCBC_OID + IV_OCTET + KEY_OCTET;
-    
-    console.log(SEQUENCE);
-    var result = crypt.hexStringToArrayBuffer(SEQUENCE);
-    return crypt.arrayBufferToBase64(result);
+
+    var AES256GCM_OID = '060960864801650304012e';
+    var AES192GCM_OID = '060960864801650304011a';
+    var AES128GCM_OID = '0609608648016503040106';
+
+    var AES256CBC_OID = '060960864801650304012a';
+    var AES192CBC_OID = '0609608648016503040116';
+    var AES128CBC_OID = '0609608648016503040102';
+
+    var AES256CFB_OID = '060960864801650304012c';
+    var AES192CFB_OID = '0609608648016503040118';
+    var AES128CFB_OID = '06086086480165030404';
+
+    var SHA512_OID = '06082a864886f70d020b0500';
+    var SHA384_OID = '06082a864886f70d020a0500';
+    var SHA256_OID = '06082a864886f70d02090500';
+    var SHA1_OID = '06082a864886f70d02070500';
+
+    var ITER_INTEGER = '02' + d2h(iterations.length / 2) + iterations;
+    var LENGTH_INTEGER = '02' + d2h(keyLength.length / 2) + keyLength;
+
+    var KEY_OCTET = '0482' + d2h(wrappedKey) + wrappedKey;
+    var SALT_OCTET = '04' + d2h(salt) + salt;
+    var IV_OCTET = '04' + d2h(iv) + iv;
+
+    switch (cipher) {
+        case 'AES-GCM' :
+            if (keyLength == 256) {
+                opt.CIPHER_OID = AES256GCM_OID;
+            } else if (keyLength == 192) {
+                opt.CIPHER_OID = AES192GCM_OID;
+            } else if (keyLength == 128) {
+                opt.CIPHER_OID = AES128GCM_OID;
+            }
+            break;
+        case 'AES-CBC' :
+            if (keyLength == 256) {
+                opt.CIPHER_OID = AES256CBC_OID;
+            } else if (keyLength == 192) {
+                opt.CIPHER_OID = AES192CBC_OID;
+            } else if (keyLength == 128) {
+                opt.CIPHER_OID = AES128CBC_OID;
+            }
+            break;
+        case 'AES-CFB' :
+            if (keyLength == 256) {
+                opt.CIPHER_OID = AES256CFB_OID;
+            } else if (keyLength == 192) {
+                opt.CIPHER_OID = AES192CFB_OID;
+            } else if (keyLength == 128) {
+                opt.CIPHER_OID = AES128CFB_OID;
+            }
+            break;
+    }
+
+    switch (hash) {
+        case 'SHA-512' :
+            opt.HASH_OID = SHA512_OID;
+            break;
+        case 'SHA-384' :
+            opt.HASH_OID = SHA384_OID;
+            break;
+        case 'SHA-256' :
+            opt.HASH_OID = SHA256_OID;
+            break;
+        case 'SHA-1' :
+            opt.HASH_OID = SHA1_OID;
+    }
+
+    opt.SEQUENCE_AES_CONTAINER = '30' + d2h(opt.CIPHER_OID + IV_OCTET);
+    opt.SEQUENCE_HASH_CONTAINER = '30' + d2h(opt.HASH_OID);
+    opt.SEQUENCE_PBKDF2_INNER_CONTAINER = '30' + d2h(SALT_OCTET + ITER_INTEGER + opt.SEQUENCE_HASH_CONTAINER + opt.HASH_OID);
+    opt.SEQUENCE_PBKDF2_CONTAINER = '30' + d2h(PBKDF2_OID + opt.SEQUENCE_PBKDF2_INNER_CONTAINER + SALT_OCTET + ITER_INTEGER + opt.SEQUENCE_HASH_CONTAINER + opt.HASH_OID);
+    opt.SEQUENCE_PBES2_INNER_CONTAINER = '30' + d2h(opt.SEQUENCE_PBKDF2_CONTAINER + PBKDF2_OID + opt.SEQUENCE_PBKDF2_INNER_CONTAINER + SALT_OCTET + ITER_INTEGER + opt.SEQUENCE_HASH_CONTAINER + opt.HASH_OID + opt.SEQUENCE_AES_CONTAINER + opt.CIPHER_OID + IV_OCTET);
+    opt.SEQUENCE_PBES2_CONTAINER = '30' + d2h(PBES2_OID + opt.SEQUENCE_PBES2_INNER_CONTAINER + opt.SEQUENCE_PBKDF2_CONTAINER + PBKDF2_OID + opt.SEQUENCE_PBKDF2_INNER_CONTAINER + SALT_OCTET + ITER_INTEGER + opt.SEQUENCE_HASH_CONTAINER + opt.HASH_OID + opt.SEQUENCE_AES_CONTAINER + opt.CIPHER_OID + IV_OCTET);
+
+    var SEQUENCE_PARAMETERS = opt.SEQUENCE_PBES2_CONTAINER + PBES2_OID + opt.SEQUENCE_PBES2_INNER_CONTAINER + opt.SEQUENCE_PBKDF2_CONTAINER + PBKDF2_OID + opt.SEQUENCE_PBKDF2_INNER_CONTAINER + SALT_OCTET + ITER_INTEGER + opt.SEQUENCE_HASH_CONTAINER + opt.HASH_OID + opt.SEQUENCE_AES_CONTAINER + opt.CIPHER_OID + IV_OCTET;
+    var SEQUENCE_LENGTH = d2h(SEQUENCE_PARAMETERS + KEY_OCTET);
+    var SEQUENCE = '3082' + SEQUENCE_LENGTH + SEQUENCE_PARAMETERS + KEY_OCTET;
+
+    var asnKey = self.hexStringToArrayBuffer(SEQUENCE);
+    var pemKey = self.arrayBufferToBase64(asnKey);
+    pemKey = addNewLines(pemKey);
+    pemKey = '-----BEGIN ENCRYPTED PRIVATE KEY-----\r\n' + pemKey + '-----END ENCRYPTED PRIVATE KEY-----';
+
+    return pemKey;
 }
 
 function fromAsn1(pem, crypt) {
+    var opt = {};
     pem = removeLines(pem);
     pem = pem.replace('-----BEGIN ENCRYPTED PRIVATE KEY-----', '');
     pem = pem.replace('-----END ENCRYPTED PRIVATE KEY-----', '');
     pem = crypt.base64ToArrayBuffer(pem);
+
     var hex = crypt.arrayBufferToHexString(pem);
-    
-    var PBKDF2_OID = hex.indexOf('06092a864886f70d01050c');
-    var AESCBC_OID = hex.indexOf('060960864801650304012a');
-    var AESGCM_OID = hex.indexOf('060960864801650304012e');
-    var AESCFB_OID = hex.indexOf('060960864801650304012c');
-    
-    var ivLength = null;
-    var iv = null;
-    var cipherSuite = null;
-    var saltLength = parseInt(hex.substring(PBKDF2_OID + 28, PBKDF2_OID + 30), 16);
-    var salt = hex.substring(PBKDF2_OID + 30, PBKDF2_OID + (saltLength * 2) + 30);
-    var sequenceLength = parseInt(hex.substring(10, 12), 16);
-    var keyLength = parseInt(hex.substring((sequenceLength + 8) * 2, ((sequenceLength + 8) * 2) + 4), 16);
-    var encryptedData = hex.substring((sequenceLength + 10) * 2, ((sequenceLength + 10) * 2) + (keyLength * 2));
-    
-    if(AESCBC_OID > 0) {
-        ivLength = parseInt(hex.substring(AESCBC_OID + 24, AESCBC_OID + 26), 16);
-        iv = hex.substring(AESCBC_OID + 26, AESCBC_OID + (ivLength * 2) + 26);
-        cipherSuite = 'AES-CBC';
-    } else if(AESGCM_OID > 0) {
-        ivLength = parseInt(hex.substring(AESGCM_OID + 24, AESGCM_OID + 26), 16);
-        iv = hex.substring(AESGCM_OID + 26, AESGCM_OID + (ivLength * 2) + 26);
-        cipherSuite = 'AES-GCM';
-    } else if(AESCFB_OID > 0) {
-        ivLength = parseInt(hex.substring(AESCFB_OID + 24, AESCFB_OID + 26), 16);
-        iv = hex.substring(AESCFB_OID + 26, AESCFB_OID + (ivLength * 2) + 26);
-        cipherSuite = 'AES-CFB';
+    opt.data = hex;
+
+    var PBES2_OID = '06092a864886f70d01050d';
+    var PBKDF2_OID = '06092a864886f70d01050c';
+
+    var AES256GCM_OID = '060960864801650304012e';
+    var AES192GCM_OID = '060960864801650304011a';
+    var AES128GCM_OID = '0609608648016503040106';
+
+    var AES256CBC_OID = '060960864801650304012a';
+    var AES192CBC_OID = '0609608648016503040116';
+    var AES128CBC_OID = '0609608648016503040102';
+
+    var AES256CFB_OID = '060960864801650304012c';
+    var AES192CFB_OID = '0609608648016503040118';
+    var AES128CFB_OID = '06086086480165030404';
+
+    var SHA512_OID = '06082a864886f70d020b';
+    var SHA384_OID = '06082a864886f70d020a';
+    var SHA256_OID = '06082a864886f70d0209';
+    var SHA1_OID = '06082a864886f70d0207';
+
+    if (opt.data.includes(PBES2_OID) && opt.data.includes(PBKDF2_OID)) {
+        opt.valid = true;
     }
-    
+
+    opt.saltBegin = opt.data.indexOf(PBKDF2_OID) + 28;
+
+    if (opt.data.includes(AES256GCM_OID)) {
+        opt.cipher = 'AES-GCM';
+        opt.keyLength = 256;
+        opt.ivBegin = opt.data.indexOf(AES256GCM_OID) + 24;
+    } else if (opt.data.includes(AES192GCM_OID)) {
+        opt.cipher = 'AES-GCM';
+        opt.keyLength = 192;
+        opt.ivBegin = opt.data.indexOf(AES192GCM_OID) + 24;
+    } else if (opt.data.includes(AES128GCM_OID)) {
+        opt.cipher = 'AES-GCM';
+        opt.keyLength = 128;
+        opt.ivBegin = opt.data.indexOf(AES128GCM_OID) + 24;
+    } else if (opt.data.includes(AES256CBC_OID)) {
+        opt.cipher = 'AES-CBC';
+        opt.keyLength = 256;
+        opt.ivBegin = opt.data.indexOf(AES256CBC_OID) + 24;
+    } else if (opt.data.includes(AES192CBC_OID)) {
+        opt.cipher = 'AES-CBC';
+        opt.keyLength = 192;
+        opt.ivBegin = opt.data.indexOf(AES192CBC_OID) + 24;
+    } else if (opt.data.includes(AES128CBC_OID)) {
+        opt.cipher = 'AES-CBC';
+        opt.keyLength = 128;
+        opt.ivBegin = opt.data.indexOf(AES128CBC_OID) + 24;
+    } else if (opt.data.includes(AES256CFB_OID)) {
+        opt.cipher = 'AES-CFB';
+        opt.keyLength = 256;
+        opt.ivBegin = opt.data.indexOf(AES256CFB_OID) + 24;
+    } else if (opt.data.includes(AES192CFB_OID)) {
+        opt.cipher = 'AES-CFB';
+        opt.keyLength = 192;
+        opt.ivBegin = opt.data.indexOf(AES192CFB_OID) + 24;
+    } else if (opt.data.includes(AES128CFB_OID)) {
+        opt.cipher = 'AES-CFB';
+        opt.keyLength = 128;
+        opt.ivBegin = opt.data.indexOf(AES128CFB_OID) + 22;
+    }
+
+    if (opt.data.includes(SHA512_OID)) {
+        opt.hash = 'SHA-512';
+    } else if (opt.data.includes(SHA384_OID)) {
+        opt.hash = 'SHA-384';
+    } else if (opt.data.includes(SHA256_OID)) {
+        opt.hash = 'SHA-256';
+    } else if (opt.data.includes(SHA1_OID)) {
+        opt.hash = 'SHA-1';
+    }
+
+    opt.saltLength = parseInt(opt.data.substr(opt.saltBegin, 2), 16);
+    opt.ivLength = parseInt(opt.data.substr(opt.ivBegin, 2), 16);
+
+    opt.salt = opt.data.substr(opt.saltBegin + 2, opt.saltLength * 2);
+    opt.iv = opt.data.substr(opt.ivBegin + 2, opt.ivLength * 2);
+
+    opt.iterBegin = opt.saltBegin + 4 + (opt.saltLength * 2);
+    opt.iterLength = parseInt(opt.data.substr(opt.iterBegin, 2), 16);
+    opt.iter = parseInt(opt.data.substr(opt.iterBegin + 2, opt.iterLength * 2), 16);
+
+    opt.sequenceLength = parseInt(opt.data.substr(10, 2), 16);
+    opt.encryptedDataBegin = 16 + (opt.sequenceLength * 2);
+    opt.encryptedDataLength = parseInt(opt.data.substr(opt.encryptedDataBegin, 4), 16);
+    opt.encryptedData = opt.data.substr(opt.encryptedDataBegin + 4, (opt.encryptedDataLength * 2));
+
     var res = {
-        salt: crypt.hexStringToArrayBuffer(salt),
-        iterations: 2048,
-        cipherSuite: cipherSuite,
-        iv: crypt.hexStringToArrayBuffer(iv),
-        encryptedData: crypt.hexStringToArrayBuffer(encryptedData)
+        salt: crypt.hexStringToArrayBuffer(opt.salt),
+        iv: crypt.hexStringToArrayBuffer(opt.iv),
+        cipher: opt.cipher,
+        keyLength: opt.keyLength,
+        hash: opt.hash,
+        iter: opt.iter,
+        encryptedData: crypt.hexStringToArrayBuffer(opt.encryptedData)
     };
-    
+
     return res;
 }
 
@@ -189,26 +345,26 @@ OpenCrypto.prototype.arrayBufferToString = function(arrayBuffer) {
     if (typeof arrayBuffer !== 'object') {
         throw new TypeError('Expected input to be an ArrayBuffer Object');
     }
-    
+
     var decoder = new TextDecoder('utf-8');
     return decoder.decode(arrayBuffer);
 };
- 
+
 OpenCrypto.prototype.stringToArrayBuffer = function(str) {
     if (typeof str !== 'string') {
         throw new TypeError('Expected input to be a String');
     }
-    
+
     var encoder = new TextEncoder('utf-8');
     var byteArray = encoder.encode(str);
     return byteArray.buffer;
 };
- 
+
 OpenCrypto.prototype.arrayBufferToHexString = function(arrayBuffer) {
     if (typeof arrayBuffer !== 'object') {
         throw new TypeError('Expected input to be an ArrayBuffer Object');
     }
-    
+
     var byteArray = new Uint8Array(arrayBuffer);
     var hexString = '';
     var nextHexByte;
@@ -220,7 +376,7 @@ OpenCrypto.prototype.arrayBufferToHexString = function(arrayBuffer) {
         }
         hexString += nextHexByte;
     }
-    
+
     return hexString;
 };
 
@@ -228,16 +384,16 @@ OpenCrypto.prototype.hexStringToArrayBuffer = function(hexString) {
     if (typeof hexString !== 'string') {
         throw new TypeError('Expected input of hexString to be a String');
     }
-    
+
     if ((hexString.length % 2) !== 0) {
         throw new RangeError('Expected string to be an even number of characters');
     }
-    
+
     var byteArray = new Uint8Array(hexString.length / 2);
     for (var i = 0; i < hexString.length; i += 2) {
         byteArray[i / 2] = parseInt(hexString.substring(i, i + 2), 16);
     }
-    
+
     return byteArray.buffer;
 };
 
@@ -245,7 +401,7 @@ OpenCrypto.prototype.arrayBufferToBase64 = function(arrayBuffer) {
     if (typeof arrayBuffer !== 'object') {
         throw new TypeError('Expected input to be an ArrayBuffer Object');
     }
-    
+
     return encodeAb(arrayBuffer);
 };
 
@@ -253,7 +409,7 @@ OpenCrypto.prototype.base64ToArrayBuffer = function(b64) {
     if (typeof b64 !== 'string') {
         throw new TypeError('Expected input to be a base64 String');
     }
-    
+
     return decodeAb(b64);
 };
 
@@ -265,35 +421,35 @@ OpenCrypto.prototype.base64ToArrayBuffer = function(b64) {
  * - algo        {String}   default: "SHA-512" uses SHA-512 hash algorithm as default
  * - extractable {Boolean}  default: "true" whether the key is extractable
  */
-OpenCrypto.prototype.getKeyPair = function(bits, usage, algo, extractable) {
+OpenCrypto.prototype.getKeyPair = function(bits, usage, alg, extractable) {
     var bits = (typeof bits !== 'undefined') ? bits : 2048;
     var usage = (typeof usage !== 'undefined') ? usage : ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'];
-    var algo = (typeof algo !== 'undefined') ? algo : 'SHA-512';
+    var alg = (typeof alg !== 'undefined') ? alg : 'SHA-512';
     var extractable = (typeof extractable !== 'undefined') ? extractable : true;
     var self = this;
     return new Promise(function(resolve, reject) {
         if (typeof bits !== 'number') {
             throw new TypeError('Expected input of bits to be a Number');
         }
-        
+
         if (typeof usage !== 'object') {
             throw new TypeError('Expected input of usage to be an Array');
         }
-        
-        if (typeof algo !== 'string') {
+
+        if (typeof alg !== 'string') {
             throw new TypeError('Expected input of algo expected to be a String');
         }
-        
+
         if (typeof extractable !== 'boolean') {
             throw new TypeError('Expected input of extractable to be a Boolean');
         }
-        
+
         cryptoApi.generateKey(
             {
                 name: 'RSA-OAEP',
                 modulusLength: bits,
                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                hash: {name: algo}
+                hash: {name: alg}
             },
             extractable,
             usage
@@ -316,7 +472,7 @@ OpenCrypto.prototype.getKeyPair = function(bits, usage, algo, extractable) {
          if (typeof privateKey !== 'object') {
              throw new TypeError('Expected input to be a CryptoKey Object');
          }
-         
+
          cryptoApi.exportKey(
              'pkcs8',
              privateKey
@@ -324,7 +480,7 @@ OpenCrypto.prototype.getKeyPair = function(bits, usage, algo, extractable) {
              var b64 = self.arrayBufferToBase64(exportedPrivateKey);
              var pem = addNewLines(b64);
              pem = '-----BEGIN PRIVATE KEY-----\r\n' + pem + '-----END PRIVATE KEY-----';
-             
+
              resolve(pem);
          }).catch(function(err) {
              reject(err);
@@ -343,12 +499,12 @@ OpenCrypto.prototype.pemPrivateToCrypto = function(pem) {
         if (typeof pem !== 'string') {
             throw new TypeError('Expected input of PEM to be a String');
         }
-        
+
         pem = pem.replace('-----BEGIN PRIVATE KEY-----', '');
         var b64 = pem.replace('-----END PRIVATE KEY-----', '');
         b64 = removeLines(b64);
         var arrayBuffer = self.base64ToArrayBuffer(b64);
-        
+
         cryptoApi.importKey(
             'pkcs8',
             arrayBuffer,
@@ -377,7 +533,7 @@ OpenCrypto.prototype.cryptoPublicToPem = function(publicKey) {
         if (typeof publicKey !== 'object') {
             throw new TypeError('Expected input to be a CryptoKey Object');
         }
-        
+
         cryptoApi.exportKey(
             'spki',
             publicKey
@@ -385,7 +541,7 @@ OpenCrypto.prototype.cryptoPublicToPem = function(publicKey) {
             var b64 = self.arrayBufferToBase64(exportedPublicKey);
             var pem = addNewLines(b64);
             pem = '-----BEGIN PUBLIC KEY-----\r\n' + pem + '-----END PUBLIC KEY-----';
-            
+
             resolve(pem);
         }).catch(function(err) {
             reject(err);
@@ -404,12 +560,12 @@ OpenCrypto.prototype.pemPublicToCrypto = function(pem) {
         if (typeof pem !== 'string') {
             throw new TypeError('Expected input of PEM to be a String');
         }
-        
+
         pem = removeLines(pem);
         pem = pem.replace('-----BEGIN PUBLIC KEY-----', '');
         var b64 = pem.replace('-----END PUBLIC KEY-----', '');
         var arrayBuffer = self.base64ToArrayBuffer(b64);
-        
+
         cryptoApi.importKey(
             'spki',
             arrayBuffer,
@@ -432,21 +588,47 @@ OpenCrypto.prototype.pemPublicToCrypto = function(pem) {
  * Encrypts asymmetric private key based on passphrase to enable storage in unsecure environment
  * - privateKey        {CryptoKey}  default: "undefined" private key in CryptoKey format
  * - passphrase        {String}     default: "undefined" any passphrase string
+ * - iterations        {Number}     default: "300000"
+ * - hash              {String}     default: "SHA-512"
+ * - cipher            {String}     default: "AES-CBC"
+ * - keyLength         {Number}     default: "256"
  */
-OpenCrypto.prototype.encryptPrivateKey = function(privateKey, passphrase) {
+OpenCrypto.prototype.encryptPrivateKey = function(privateKey, passphrase, iterations, alg, cipher, keyLength) {
+    var iterations = (typeof iterations !== 'undefined') ? iterations : 64000;
+    var alg = (typeof alg !== 'undefined') ? alg : 'SHA-512';
+    var cipher = (typeof cipher !== 'undefined') ? cipher : 'AES-CBC';
+    var keyLength = (typeof keyLength !== 'undefined') ? keyLength : 256;
     var self = this;
+
     return new Promise(function(resolve, reject) {
         if (typeof privateKey !== 'object') {
             throw new TypeError('Expected input of privateKey to be a CryptoKey Object');
         }
-        
+
         if (typeof passphrase !== 'string') {
             throw new TypeError('Expected input of passphrase to be a String');
         }
-        
+
+        if (typeof iterations !== 'number') {
+            throw new TypeError('Expected input of iterations to be a Number');
+        }
+
+        if (typeof alg !== 'string') {
+            throw new TypeError('Expected input of iterations to be a String');
+        }
+
+        var ivLength = null;
+        if (cipher == 'AES-GCM') {
+            ivLength = 12;
+        } else if (cipher == 'AES-CBC') {
+            ivLength = 16;
+        } else if (cipher == 'AES-CFB') {
+            ivLength = 16;
+        }
+
         var salt = securePRNG.getRandomValues(new Uint8Array(16));
-        var iv = securePRNG.getRandomValues(new Uint8Array(16));
-        
+        var iv = securePRNG.getRandomValues(new Uint8Array(ivLength));
+
         cryptoApi.importKey(
             'raw',
             self.stringToArrayBuffer(passphrase),
@@ -460,13 +642,13 @@ OpenCrypto.prototype.encryptPrivateKey = function(privateKey, passphrase) {
                 {
                     name: 'PBKDF2',
                     salt: salt,
-                    iterations: 2048,
-                    hash: 'SHA-1'
+                    iterations: iterations,
+                    hash: alg
                 },
                 baseKey,
                 {
-                    name: 'AES-CBC',
-                    length: 256
+                    name: cipher,
+                    length: keyLength
                 },
                 true,
                 ['wrapKey']
@@ -476,13 +658,11 @@ OpenCrypto.prototype.encryptPrivateKey = function(privateKey, passphrase) {
                     privateKey,
                     derivedKey,
                     {
-                        name: 'AES-CBC',
+                        name: cipher,
                         iv: iv
                     }
                 ).then(function(wrappedKey) {
-                    var asnKey = toAsn1(wrappedKey, salt, iv, self);
-                    var pemKey = addNewLines(asnKey);
-                    pemKey = '-----BEGIN ENCRYPTED PRIVATE KEY-----\r\n' + pemKey + '-----END ENCRYPTED PRIVATE KEY-----';
+                    var pemKey = toAsn1(wrappedKey, salt, iv, iterations, alg, cipher, keyLength, self);
                     resolve(pemKey);
                 }).catch(function(err) {
                     reject(err);
@@ -508,12 +688,12 @@ OpenCrypto.prototype.decryptPrivateKey = function(encryptedPrivateKey, passphras
         if (typeof encryptedPrivateKey !== 'string') {
             throw new TypeError('Expected input of encryptedPrivateKey to be a base64 String');
         }
-        
+
         if (typeof passphrase !== 'string') {
             throw new TypeError('Expected input of passphrase to be a String');
         }
-        
-        encryptedPrivateKey = fromAsn1(encryptedPrivateKey, self);
+
+        var epki = fromAsn1(encryptedPrivateKey, self);
         cryptoApi.importKey(
             'raw',
             self.stringToArrayBuffer(passphrase),
@@ -526,29 +706,29 @@ OpenCrypto.prototype.decryptPrivateKey = function(encryptedPrivateKey, passphras
             cryptoApi.deriveKey(
                 {
                     name: 'PBKDF2',
-                    salt: encryptedPrivateKey.salt,
-                    iterations: encryptedPrivateKey.iterations,
-                    hash: 'SHA-1'
+                    salt: epki.salt,
+                    iterations: epki.iter,
+                    hash: epki.hash
                 },
                 baseKey,
                 {
-                    name: encryptedPrivateKey.cipherSuite,
-                    length: 256
+                    name: epki.cipher,
+                    length: epki.keyLength
                 },
                 true,
                 ['unwrapKey']
             ).then(function(derivedKey) {
                 cryptoApi.unwrapKey(
                     'pkcs8',
-                    encryptedPrivateKey.encryptedData,
+                    epki.encryptedData,
                     derivedKey,
                     {
-                        name: encryptedPrivateKey.cipherSuite,
-                        iv: encryptedPrivateKey.iv
+                        name: epki.cipher,
+                        iv: epki.iv
                     },
                     {
                         name: 'RSA-OAEP',
-                        hash: {name: 'SHA-512'}
+                        hash: {name: epki.hash}
                     },
                     true,
                     ['decrypt', 'unwrapKey']
@@ -579,11 +759,11 @@ OpenCrypto.prototype.encryptPublic = function(publicKey, data) {
         if (Object.prototype.toString.call(publicKey) !== '[object CryptoKey]' && publicKey.type !== 'public') {
             throw new TypeError('Expected input of privateKey to be a CryptoKey of type public');
         }
-        
+
         if (typeof data !== 'string') {
             throw new TypeError('Expected input of data to be a String');
         }
-        
+
         cryptoApi.encrypt(
             {
                 name: 'RSA-OAEP'
@@ -611,11 +791,11 @@ OpenCrypto.prototype.decryptPrivate = function(privateKey, encryptedData) {
         if (Object.prototype.toString.call(privateKey) !== '[object CryptoKey]' && privateKey.type !== 'private') {
             throw new TypeError('Expected input of privateKey to be a CryptoKey of type private');
         }
-        
+
         if (typeof encryptedData !== 'string') {
             throw new TypeError('Expected input of encryptedData to be a String');
         }
-        
+
         cryptoApi.decrypt(
             {
                 name: 'RSA-OAEP'
@@ -645,11 +825,11 @@ OpenCrypto.prototype.encryptKey = function(publicKey, sessionKey, publicKeyHash)
         if (Object.prototype.toString.call(publicKey) !== '[object CryptoKey]' && publicKey.type !== 'public') {
             throw new TypeError('Expected input of publicKey to be a CryptoKey of type public');
         }
-        
+
         if (Object.prototype.toString.call(sessionKey) !== '[object CryptoKey]' && sessionKey.type !== 'secret') {
             throw new TypeError('Expected input of sessionKey to be a CryptoKey of type secret');
         }
-        
+
         cryptoApi.wrapKey(
             'raw',
             sessionKey,
@@ -677,8 +857,8 @@ OpenCrypto.prototype.encryptKey = function(publicKey, sessionKey, publicKeyHash)
  * - privateKeyLength        {Number} default: "2048"
  * - privateKeyHash          {String} default: "SHA-512"
  */
-OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, cipherSuite, keyLength, privateKeyLength, privateKeyHash) {
-    var cipherSuite = (typeof cipherSuite !== 'undefined') ? cipherSuite : 'AES-GCM';
+OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, cipher, keyLength, privateKeyLength, privateKeyHash) {
+    var cipher = (typeof cipher !== 'undefined') ? cipher : 'AES-GCM';
     var keyLength = (typeof keyLength !== 'undefined') ? keyLength : 256;
     var privateKeyLength = (typeof privateKeyLength !== 'undefined') ? privateKeyLength : 2048;
     var privateKeyHash = (typeof privateKeyHash !== 'undefined') ? privateKeyHash : 'SHA-512';
@@ -687,27 +867,27 @@ OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, ciph
         if (Object.prototype.toString.call(privateKey) !== '[object CryptoKey]' && privateKey.type !== 'private') {
             throw new TypeError('Expected input of privateKey to be a CryptoKey of type private');
         }
-        
+
         if (typeof encryptedSessionKey !== 'string') {
             throw new TypeError('Expected input of encryptedSessionKey to be a base64 String');
         }
-        
-        if (typeof cipherSuite !== 'string') {
+
+        if (typeof cipher !== 'string') {
             throw new TypeError('Expected input of cipherSuite to be a String');
         }
-        
+
         if (typeof keyLength !== 'number') {
             throw new TypeError('Expected input of keyLength to be a Number');
         }
-        
+
         if (typeof privateKeyLength !== 'number') {
             throw new TypeError('Expected input of privateKeyLength to be a Number');
         }
-        
+
         if (typeof privateKeyHash !== 'string') {
             throw new TypeError('Expected input of privateKeyHash to be a String');
         }
-        
+
         cryptoApi.unwrapKey(
             'raw',
             encryptedSessionKey,
@@ -719,7 +899,7 @@ OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, ciph
                 hash: {name: privateKeyHash}
             },
             {
-                name: cipherSuite,
+                name: cipher,
                 length: keyLength
             },
             true,
@@ -741,32 +921,32 @@ OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, ciph
  * - extractable       {Boolean} default: "false" whether the key can be exported
  * - cipherMode        {String}  default: "AES-GCM" Cipher block mode operation
  */
- OpenCrypto.prototype.getSessionKey = function(bits, usage, extractable, cipherMode) {
+ OpenCrypto.prototype.getSessionKey = function(bits, usage, extractable, cipher) {
      var bits = (typeof bits !== 'undefined') ? bits : 256;
      var usage = (typeof usage !== 'undefined') ? usage : ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'];
      var extractable = (typeof extractable !== 'undefined') ? extractable : true;
-     var cipherMode = (typeof cipherMode !== 'undefined') ? cipherMode : 'AES-GCM';
+     var cipher = (typeof cipher !== 'undefined') ? cipher : 'AES-GCM';
      var self = this;
      return new Promise(function(resolve, reject) {
          if (typeof bits !== 'number') {
              throw new TypeError('Expected input of bits to be a Number');
          }
-         
+
          if (typeof usage !== 'object') {
              throw new TypeError('Expected input of usage to be an Array');
          }
-         
+
          if (typeof extractable !== 'boolean') {
              throw new TypeError('Expected input of extractable expected to be a Boolean');
          }
-         
-         if (typeof cipherMode !== 'string') {
+
+         if (typeof cipher !== 'string') {
              throw new TypeError('Expected input of cipherMode expected to be a String');
          }
-         
+
          cryptoApi.generateKey(
              {
-                 name: cipherMode,
+                 name: cipher,
                  length: bits
              },
              extractable,
@@ -778,7 +958,7 @@ OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, ciph
          });
      });
  };
- 
+
  /**
  *
  * Encrypts data using symmetric / session key, converts them to
@@ -793,11 +973,11 @@ OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, ciph
          if (typeof sessionKey !== 'object') {
              throw new TypeError('Expected input of sessionKey to be a CryptoKey Object');
          }
-         
+
          if (typeof data !== 'string') {
              throw new TypeError('Expected input of data to be a String');
          }
-         
+
          var ivAb = securePRNG.getRandomValues(new Uint8Array(12));
          cryptoApi.encrypt(
              {
@@ -816,7 +996,7 @@ OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, ciph
          });
      });
  };
- 
+
  /**
  *
  * Decrypts data using symmetric / session key, extracts IV from
@@ -831,16 +1011,16 @@ OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, ciph
          if (typeof sessionKey !== 'object') {
              throw new TypeError('Expected input of sessionKey to be a CryptoKey Object');
          }
-         
+
          if (typeof encryptedData !== 'string') {
              throw new TypeError('Expected input of encryptedData to be a String');
          }
-         
+
          var ivB64 = encryptedData.substring(0, 16);
          var encryptedB64 = encryptedData.substring(16);
          var ivAb = self.base64ToArrayBuffer(ivB64);
          var encryptedAb = self.base64ToArrayBuffer(encryptedB64);
-         
+
          cryptoApi.decrypt(
              {
                  name: 'AES-GCM',
@@ -863,23 +1043,29 @@ OpenCrypto.prototype.decryptKey = function(privateKey, encryptedSessionKey, ciph
  * - passphrase        {String}  default: "undefined" any passphrase string
  * - salt              {String}  default: "undefined" any salt, may be unique user ID for example
  * - iterations        {Number}  default: "300000"    number of iterations is 300 000 (Recommended)
+ * - alg               {String}  default: "SHA-512"   hash algorithm
  */
-OpenCrypto.prototype.keyFromPassphrase = function(passphrase, salt, iterations) {
+OpenCrypto.prototype.keyFromPassphrase = function(passphrase, salt, iterations, alg) {
     var iterations = (typeof iterations !== 'undefined') ? iterations : 300000;
+    var alg = (typeof alg !== 'undefined') ? alg : 'SHA-512';
     var self = this;
     return new Promise(function(resolve, reject) {
         if (typeof passphrase !== 'string') {
             throw new TypeError('Expected input of passphrase to be a String');
         }
-        
+
         if (typeof salt !== 'string') {
             throw new TypeError('Expected input of salt to be a String');
         }
-        
+
         if (typeof iterations !== 'number') {
-            throw new TypeError('Expected input of iterations to be a number');
+            throw new TypeError('Expected input of iterations to be a Number');
         }
-        
+
+        if (typeof alg !== 'string') {
+            throw new TypeError('Expected input of alg to be a String');
+        }
+
         cryptoApi.importKey(
             'raw',
             self.stringToArrayBuffer(passphrase),
@@ -894,7 +1080,7 @@ OpenCrypto.prototype.keyFromPassphrase = function(passphrase, salt, iterations) 
                     name: 'PBKDF2',
                     salt: self.stringToArrayBuffer(salt),
                     iterations: iterations,
-                    hash: 'SHA-256'
+                    hash: alg
                 },
                 baseKey,
                 {
@@ -908,13 +1094,107 @@ OpenCrypto.prototype.keyFromPassphrase = function(passphrase, salt, iterations) 
                     'raw',
                     derivedKey
                 ).then(function(exportedKey) {
-                    resolve(exportedKey);
+                    resolve(self.arrayBufferToHexString(exportedKey));
                 }).catch(function(err) {
                     reject(err);
                 });
             }).catch(function(err) {
                 reject(err);
             });
+        }).catch(function(err) {
+            reject(err);
+        });
+    });
+};
+
+/**
+ *
+ * Method for getting fingerprint of RSA public or private key
+ * - key              {CryptoKey}  default: "undefined"
+ * - alg              {String}      default: "SHA-1" can be used SHA-256, SHA-384 or SHA-512
+ */
+OpenCrypto.prototype.cryptoKeyToFingerprint = function(key, alg) {
+    var alg = (typeof alg !== 'undefined') ? alg : 'SHA-1';
+    var self = this;
+    return new Promise(function(resolve, reject) {
+        if (typeof key !== 'object') {
+            throw new TypeError('Expected input of key to be a CryptoKey Object');
+        }
+
+        if (typeof alg !== 'string') {
+            throw new TypeError('Expected input of hash to be a String');
+        }
+
+        var tmpKeyType = null;
+        if (key.type == 'public') {
+            tmpKeyType = 'spki';
+        } else {
+            tmpKeyType = 'pkcs8';
+        }
+
+        cryptoApi.exportKey(
+            tmpKeyType,
+            key
+        ).then(function(keyAb) {
+            cryptoApi.digest(
+                {
+                    name: alg,
+                },
+                keyAb
+            ).then(function(fingerprint) {
+                resolve(self.arrayBufferToHexString(fingerprint).toUpperCase().replace(/(.{4})/g, '$1 ').trim());
+            }).catch(function(err) {
+                reject(err);
+            });
+        }).catch(function(err) {
+            reject(err);
+        });
+    });
+};
+
+/**
+ *
+ * Method for getting random salt using cryptographically strong PRNG
+ * - Size              {number}  default: "16"
+ */
+OpenCrypto.prototype.getRandomSalt = function(size) {
+    var size = (typeof size !== 'undefined') ? size : 16;
+    var self = this;
+
+    return new Promise(function(resolve, reject) {
+        if (typeof size !== 'number') {
+            throw new TypeError('Expected input of size to be a Number');
+        }
+
+        var salt = securePRNG.getRandomValues(new Uint8Array(size));
+        var hexSalt = self.arrayBufferToHexString(salt);
+
+        resolve(hexSalt);
+    });
+};
+
+/**
+ *
+ * Generates Elliptic Curve Diffie-Hellman Key Pair
+ * - curve              {number}  default: "P-256"
+ */
+OpenCrypto.prototype.getEcKeyPair = function(curve) {
+    var curve = (typeof curve !== 'undefined') ? curve : 'P-256';
+
+    return new Promise(function(resolve, reject) {
+        if (typeof curve !== 'string') {
+            throw new TypeError('Expected input of curve to be a String');
+        }
+
+        cryptoApi.generateKey(
+            {
+                name: 'ECDH',
+                namedCurve: curve
+            },
+            true,
+            ['deriveKey', 'deriveBits']
+        ).then(function(keyPair) {
+            resolve(keyPair);
         }).catch(function(err) {
             reject(err);
         });


### PR DESCRIPTION
Extended configuration support for private key encryption according to (PKCS#8)
It is now possible to encrypt private key using these cipher modes:
AES256-GCM
AES192-GCM
AES128-GCM

AES256-CBC
AES192-CBC
AES128CBC

AES256-CFB
AES192-CFB
AES128-CFB

You can define algorithm for PBKDF2
SHA-512
SHA-384
SHA-256
SHA-1

Also added minor functions for salt generation with hex output and data fingerprint with hex output and function for ECDH key pair generation.