### PR TITLE
feat: add types for typescript projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opencrypto",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3682,6 +3682,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
     },
     "ua-parser-js": {
       "version": "0.7.22",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,17 @@
   "description": "OpenCrypto is a lightweight JavaScript library built on top of WebCryptography API",
   "main": "src/OpenCrypto.js",
   "files": [
-    "index.js"
+    "index.js",
+    "types/**/*"
   ],
+  "types": "types/OpenCrypto.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/safebash/opencrypto.git"
   },
   "scripts": {
-    "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js"
+    "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
+    "createTypes": "tsc"
   },
   "license": "MIT",
   "keywords": [
@@ -32,6 +35,7 @@
     "karma-mocha": "^2.0.1",
     "mocha": "^8.2.1",
     "puppeteer": "^5.5.0",
-    "standard": "^16.0.3"
+    "standard": "^16.0.3",
+    "typescript": "^4.1.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  // Change this to match your project
+  "include": ["src/**/*"],
+
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "types",
+  },
+}

--- a/types/OpenCrypto.d.ts
+++ b/types/OpenCrypto.d.ts
@@ -1,0 +1,287 @@
+export default class OpenCrypto {
+    /**
+     * BEGIN
+     * base64-arraybuffer
+     * GitHub @niklasvh
+     * Copyright (c) 2012 Niklas von Hertzen
+     * MIT License
+     */
+    encodeAb(arrayBuffer: any): string;
+    decodeAb(base64: any): ArrayBuffer;
+    /**
+     * END
+     * base64-arraybuffer
+     */
+    /**
+     * Method for encoding ArrayBuffer into UTF-8 String
+     */
+    arrayBufferToString(arrayBuffer: any): string;
+    /**
+     * Method for decoding String to ArrayBuffer
+     */
+    stringToArrayBuffer(str: any): ArrayBufferLike;
+    /**
+     * Method for encoding ArrayBuffer to hexadecimal String
+     */
+    arrayBufferToHexString(arrayBuffer: any): string;
+    /**
+     * Method for decoding hexadecimal String to ArrayBuffer
+     */
+    hexStringToArrayBuffer(hexString: any): ArrayBufferLike;
+    /**
+     * Method for encoding ArrayBuffer to base64 String
+     */
+    arrayBufferToBase64(arrayBuffer: any): string;
+    /**
+     * Method for decoding base64 String to ArrayBuffer
+     */
+    base64ToArrayBuffer(b64: any): ArrayBuffer;
+    /**
+     * Method for encoding decimal Number to hexadecimal String
+     */
+    decimalToHex(d: any, unsigned: any): string;
+    /**
+     * Method for addition of new lines into PEM encoded key
+     */
+    addNewLines(str: any): string;
+    /**
+     * Method that removes lines from PEM encoded key
+     */
+    removeLines(str: any): any;
+    /**
+     * Method that encodes ASN.1 information into PEM encoded key
+     */
+    toAsn1(wrappedKey: any, salt: any, iv: any, iterations: any, hash: any, cipher: any, length: any): string;
+    /**
+     * Method that retrieves ASN.1 encoded information from PEM encoded key
+     */
+    fromAsn1(pem: any): {
+        salt: ArrayBufferLike;
+        iv: ArrayBufferLike;
+        cipher: string;
+        length: number;
+        hash: string;
+        iter: number;
+        encryptedData: ArrayBufferLike;
+    };
+    /**
+     * Method that converts asymmetric private key from CryptoKey to PEM format
+     * @param {CryptoKey} privateKey default: "undefined"
+     */
+    cryptoPrivateToPem(privateKey: CryptoKey): Promise<any>;
+    /**
+     * Method that converts asymmetric private key from PEM to CryptoKey format
+     * @param {String} pem default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- ECDH: { name: 'ECDH', usages: ['deriveKey', 'deriveBits'], isExtractable: true }
+     * -- ECDSA: { name: 'ECDSA', usages: ['sign'], isExtractable: true }
+     * -- RSA-OAEP: { name: 'RSA-OAEP', hash: { name: 'SHA-512' }, usages: ['decrypt', 'unwrapKey'], isExtractable: true }
+     * -- RSA-PSS: { name: 'RSA-PSS', hash: { name: 'SHA-512' }, usages: ['sign'], isExtractable: true }
+     */
+    pemPrivateToCrypto(pem: string, options: any): Promise<any>;
+    /**
+     * Method that converts asymmetric public key from CryptoKey to PEM format
+     * @param {CryptoKey} publicKey default: "undefined"
+     */
+    cryptoPublicToPem(publicKey: CryptoKey): Promise<any>;
+    /**
+     * Method that converts asymmetric public key from PEM to CryptoKey format
+     * @param {String} publicKey default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- ECDH: { name: 'ECDH', usages: [], isExtractable: true }
+     * -- ECDSA: { name: 'ECDSA', usages: ['verify'], isExtractable: true }
+     * -- RSA-OAEP: { name: 'RSA-OAEP', hash: { name: 'SHA-512' }, usages: ['encrypt', 'wrapKey'], isExtractable: true }
+     * -- RSA-PSS: { name: 'RSA-PSS', hash: { name: 'SHA-512' }, usages: ['verify'], isExtractable: true }
+     */
+    pemPublicToCrypto(pem: any, options: any): Promise<any>;
+    /**
+     * Method that converts CryptoKey to base64
+     * @param {CryptoKey} key default: "undefined"
+     * @param {String} type default: "secret: 'raw'; private: 'pkcs8'; public: 'spki'"
+     */
+    cryptoToBase64(key: CryptoKey, type: string): Promise<any>;
+    /**
+     * Method that converts base64 encoded key to CryptoKey
+     * @param {String} key default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- AES-GCM: { name: 'AES-GCM', length: 256, usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }
+     * -- AES-CBC: { name: 'AES-CBC', length: 256, usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }
+     * -- ECDH: { name: 'ECDH', namedCurve: 'P-256', usages: ['deriveKey', 'deriveBits'], isExtractable: true }
+     * -- ECDSA: { name: 'ECDSA', namedCurve: 'P-256', usages: ['sign', 'verify'], isExtractable: true }
+     * -- RSA-OAEP: { name: 'RSA-OAEP', hash: { name: 'SHA-512' }, usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }
+     * -- RSA-PSS: { name: 'RSA-PSS', hash: { name: 'SHA-512' }, usages: ['sign', 'verify'], isExtractable: true }
+     */
+    base64ToCrypto(key: string, options: any): Promise<any>;
+    /**
+     * Method that generates asymmetric RSA-OAEP key pair
+     * @param {Integer} modulusLength default: "2048"
+     * @param {String} hash default: "SHA-512"
+     * @param {String} paddingScheme default: "RSA-OAEP"
+     * @param {Array} usages default: "['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']"
+     * @param {Boolean} isExtractable default: "true"
+     */
+    getRSAKeyPair(modulusLength: any, hash: string, paddingScheme: string, usages: any[], isExtractable: boolean): Promise<any>;
+    /**
+     * Method that encrypts data using asymmetric encryption
+     * @param {CryptoKey} publicKey default: "undefined"
+     * @param {ArrayBuffer} data default: "undefined"
+     */
+    rsaEncrypt(publicKey: CryptoKey, data: ArrayBuffer): Promise<any>;
+    /**
+     * Method that decrypts data using asymmetric encryption
+     * @param {CryptoKey} privateKey default: "undefined"
+     * @param {String} encryptedData default: "undefined"
+     */
+    rsaDecrypt(privateKey: CryptoKey, encryptedData: string): Promise<any>;
+    /**
+     * Method that generates asymmetric Elliptic Curve Diffie-Hellman key pair
+     * @param {String} curve default: "P-256"
+     * @param {String} type default: "ECDH"
+     * @param {Array} usages default: "['deriveKey', 'deriveBits']"
+     * @param {Boolean} isExtractable default: "true"
+     */
+    getECKeyPair(curve: string, type: string, usages: any[], isExtractable: boolean): Promise<any>;
+    /**
+     * Method that retrieves public key from private key
+     * @param {CryptoKey} privateKey default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- ECDH: { usages: ['deriveKey', 'deriveBits'], isExtractable: true }
+     * -- ECDSA: { usages: ['sign', 'verify'], isExtractable: true }
+     * -- RSA-OAEP: { usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }
+     * -- RSA-PSS: { usages: ['sign', 'verify'], isExtractable: true }
+     */
+    getPublicKey(privateKey: CryptoKey, options: any): Promise<any>;
+    /**
+     * Method that encrypts asymmetric private key using passphrase to enable storage in unsecure environment
+     * @param {CryptoKey} privateKey default: "undefined"
+     * @param {String} passphrase default: "undefined"
+     * @param {Number} iterations default: "64000"
+     * @param {String} hash default: "SHA-512"
+     * @param {String} cipher default: "AES-GCM"
+     * @param {Number} length default: "256"
+     */
+    encryptPrivateKey(privateKey: CryptoKey, passphrase: string, iterations: number, hash: string, cipher: string, length: number): Promise<any>;
+    /**
+     * Method that decrypts asymmetric private key using passphrase
+     * @param {String} encryptedPrivateKey default: "undefined"
+     * @param {String} passphrase default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- ECDH: { name: 'ECDH', namedCurve: 'P-256', usages: ['deriveKey', 'deriveBits'], isExtractable: true }
+     * -- ECDSA: { name: 'ECDSA', namedCurve: 'P-256', usages: ['sign'], isExtractable: true }
+     * -- RSA-OAEP: { name: 'RSA-OAEP', hash: 'SHA-512', usages: ['decrypt', 'unwrapKey'], isExtractable: true }
+     * -- RSA-PSS: { name: 'RSA-PSS', hash: 'SHA-512', usages: ['sign'], isExtractable: true }
+     */
+    decryptPrivateKey(encryptedPrivateKey: string, passphrase: string, options: any): Promise<any>;
+    /**
+     * Method that performs ECDH key agreement
+     * @param {CryptoKey} privateKey default: "undefined"
+     * @param {CryptoKey} publicKey default: "undefined"
+     * @param {Object} options default: "{ bitLength: 256, hkdfHash: 'SHA-512', hkdfSalt: "new UInt8Array()", hkdfInfo: "new UInt8Array()", cipher: 'AES-GCM', length: 256, usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }"
+     */
+    keyAgreement(privateKey: CryptoKey, publicKey: CryptoKey, options: any): Promise<any>;
+    /**
+     * Method that generates symmetric/shared key for AES encryption
+     * @param {Integer} length default: "256"
+     * @param {Object} options default: "{ cipher: 'AES-GCM', usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }"
+     */
+    getSharedKey(length: any, options: any): Promise<any>;
+    /**
+     * Method that encrypts keys
+     * @param {CryptoKey} wrappingKey default: "undefined"
+     * @param {CryptoKey} key default: "undefined"
+     */
+    encryptKey(wrappingKey: CryptoKey, key: CryptoKey): Promise<any>;
+    /**
+     * Method that decrypts keys
+     * @param {CryptoKey} unwrappingKey default: "undefined"
+     * @param {String} encryptedKey default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- AES-GCM: { type: 'raw', name: 'AES-GCM', length: 256, usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }
+     * -- AES-CBC: { type: 'raw', name: 'AES-CBC', length: 256, usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }
+     * -- ECDH: { type: "'pkcs8' or 'spki'", name: 'ECDH', namedCurve: 'P-256', usages: ['deriveKey', 'deriveBits'], isExtractable: true }
+     * -- ECDSA: { type: "'pkcs8' or 'spki'", name: 'ECDSA', namedCurve: 'P-256', usages: ['sign', 'verify'], isExtractable: true }
+     * -- RSA-OAEP: { type: "'pkcs8' or 'spki'", name: 'RSA-OAEP', hash: 'SHA-512', usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }
+     * -- RSA-PSS: { type: "'pkcs8' or 'spki'", name: 'RSA-PSS', hash: 'SHA-512', usages: ['sign', 'verify'], isExtractable: true }
+     */
+    decryptKey(unwrappingKey: CryptoKey, encryptedKey: string, options: any): Promise<any>;
+    /**
+     * Method that generates key signature using ECDSA or RSA-PSS
+     * @param {CryptoKey} privateKey default: "undefined"
+     * @param {CryptoKey} key default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- ECDSA: { hash: 'SHA-512' }
+     * -- RSA-PSS: { saltLength: 128 }
+     */
+    signKey(privateKey: CryptoKey, key: CryptoKey, options: any): Promise<any>;
+    /**
+     * Method that verifies key signature using ECDSA or RSA-PSS
+     * @param {CryptoKey} publicKey default: "undefined"
+     * @param {CryptoKey} key default: "undefined"
+     * @param {String} signature default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- ECDSA: { hash: 'SHA-512' }
+     * -- RSA-PSS: { saltLength: 128 }
+     */
+    verifyKey(publicKey: CryptoKey, key: CryptoKey, signature: string, options: any): Promise<any>;
+    /**
+     * Method that generates signature of data using ECDSA or RSA-PSS
+     * @param {CryptoKey} privateKey default: "undefined"
+     * @param {ArrayBuffer} data default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- ECDSA: { hash: 'SHA-512' }
+     * -- RSA-PSS: { saltLength: 128 }
+     */
+    sign(privateKey: CryptoKey, data: ArrayBuffer, options: any): Promise<any>;
+    /**
+     * Method that verifies data signature using ECDSA or RSA-PSS
+     * @param {CryptoKey} publicKey default: "undefined"
+     * @param {ArrayBuffer} data default: "undefined"
+     * @param {String} signature default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- ECDSA: { hash: 'SHA-512' }
+     * -- RSA-PSS: { saltLength: 128 }
+     */
+    verify(publicKey: CryptoKey, data: ArrayBuffer, signature: string, options: any): Promise<any>;
+    /**
+     * Method that encrypts data using symmetric/shared key
+     * @param {CryptoKey} sharedKey default: "undefined"
+     * @param {ArrayBuffer} data default: "undefined"
+     */
+    encrypt(sharedKey: CryptoKey, data: ArrayBuffer): Promise<any>;
+    /**
+     * Method that decrypts data using symmetric/shared key
+     * @param {CryptoKey} sharedKey default: "undefined"
+     * @param {String} encryptedData default: "undefined"
+     * @param {Object} options default: depends on algorithm below
+     * -- AES-GCM: { cipher: 'AES-GCM' }
+     * -- AES-CBC: { cipher: 'AES-CBC' }
+     */
+    decrypt(sharedKey: CryptoKey, encryptedData: string, options: any): Promise<any>;
+    /**
+     * Method that derives shared key from passphrase
+     * @param {String} passphrase default: "undefined"
+     * @param {ArrayBuffer} salt default: "undefined"
+     * @param {Number} iterations default: "64000"
+     * @param {Object} options default: "{ hash: 'SHA-512', length: 256, cipher: 'AES-GCM', usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }"
+     */
+    derivePassphraseKey(passphrase: string, salt: ArrayBuffer, iterations: number, options: any): Promise<any>;
+    /**
+     * Method that derives hash from passphrase
+     * @param {String} passphrase default: "undefined"
+     * @param {ArrayBuffer} salt default: "undefined" salt
+     * @param {Number} iterations default: "64000"
+     * @param {Object} options default: "{ hash: 'SHA-512', length: 256, cipher: 'AES-GCM', usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'], isExtractable: true }"
+     */
+    hashPassphrase(passphrase: string, salt: ArrayBuffer, iterations: number, options: any): Promise<any>;
+    /**
+     * Method that generates fingerprint of EC, RSA and AES keys
+     * @param {CryptoKey} key default: "undefined"
+     * @param {Object} options default: { hash: 'SHA-512', isBuffer: false }
+     */
+    getFingerprint(key: CryptoKey, options: any): Promise<any>;
+    /**
+     * Method that generates random bytes using cryptographically secure PRNG
+     * @param {Number} size default: "16"
+     */
+    getRandomBytes(size: number): Promise<any>;
+}


### PR DESCRIPTION
Currently we can not import `opencrypto` into an typescript project with strict checks because the exported module does not have any definitions.

This PR incorpore type definitions and an script `createTypes` that will update them when called.

Pd: If you want, I could update this PR to use [husky](https://www.npmjs.com/package/husky) with a pre commit hook, so each time somebody does a commit, the types are recreated.

Pd2: Sadly the JDDocs does not have info about several params so they are marked as `any`;